### PR TITLE
Unhappy cp1251

### DIFF
--- a/src/neoe/formatter/lua/LuaFormatter.java
+++ b/src/neoe/formatter/lua/LuaFormatter.java
@@ -193,7 +193,7 @@ public class LuaFormatter {
 
 	}
 
-	static class Env {
+	public static class Env {
 		LuaTokenType lastType = LuaTokenType.SPACE;
 		int indent;
 		int changedLine;

--- a/src/neoe/formatter/lua/LuaFormatter.java
+++ b/src/neoe/formatter/lua/LuaFormatter.java
@@ -425,7 +425,7 @@ public class LuaFormatter {
  *  stat ::= while exp do block end
 	stat ::= repeat block until exp
 	stat ::= if exp then block {elseif exp then block} [else block] end
-	stat ::= for Name ‘=’ exp ‘,’ exp [‘,’ exp] do block end
+	stat ::= for Name '=' exp ',' exp [',' exp] do block end
 	stat ::= for namelist in explist do block end
 	function f () body end
  * 


### PR DESCRIPTION
As is this .java does not format on a device running cp1251 character set

```
compile:
    [javac] <http://127.0.0.1:8080/job/integration_and_primary_bundle/ws/java_console/build.xml>:48: warning: 'includeantruntime' was not set, defaulting to build.sysclasspath=last; set to false for repeatable builds
    [javac] Compiling 805 source files to <http://127.0.0.1:8080/job/integration_and_primary_bundle/ws/java_console/build/classes>
    [javac] <http://127.0.0.1:8080/job/integration_and_primary_bundle/ws/java_console/luaformatter/src/neoe/formatter/lua/LuaFormatter.java>:442: error: unmappable character for encoding Cp1251
    [javac]     stat ::= for Name вЂ?=вЂ™ exp вЂ?,вЂ™ exp [вЂ?,вЂ™ exp] do block end
    [javac]                         ^
    [javac] <http://127.0.0.1:8080/job/integration_and_primary_bundle/ws/java_console/luaformatter/src/neoe/formatter/lua/LuaFormatter.java>:442: error: unmappable character for encoding Cp1251
    [javac]     stat ::= for Name вЂ?=вЂ™ exp вЂ?,вЂ™ exp [вЂ?,вЂ™ exp] do block end
    [javac]                                     ^
    [javac] <http://127.0.0.1:8080/job/integration_and_primary_bundle/ws/java_console/luaformatter/src/neoe/formatter/lua/LuaFormatter.java>:442: error: unmappable character for encoding Cp1251
    [javac]     stat ::= for Name вЂ?=вЂ™ exp вЂ?,вЂ™ exp [вЂ?,вЂ™ exp] do block end
    [javac]                                                  ^
    [javac] 3 errors

BUILD FAILED
```